### PR TITLE
Add support to configure portal modelName from multiple swagger fields

### DIFF
--- a/samples/DevPortal/shared-pom.xml
+++ b/samples/DevPortal/shared-pom.xml
@@ -33,6 +33,10 @@
                       path represents the signifies the path to data stored within the info object. 
                         The pipe character can be used to traverse into sub-items. For instance, with a OpenAPI document containing  { "info": { "contact": { "company": "Google" } } }, you could be access the data by setting the path to contact|company.
                       field represents the machine name of the field within the Developer portal.
+
+                      portal.model.config.name can be used to configure the modelName being sent to the SmartDocs API
+                        The caret symbol (^) is used to seperate which fields you want appended to the title from the info object and it will be replaced with _
+                        The pipe character is used to traverse into sub-items if necessary
                 -->
                 <!--
                 <configuration>
@@ -47,6 +51,7 @@
                             <field>field_approval_type</field>
                         </approval-type>
                     </portal.model.fields>
+                    <portal.model.config.name>contact|x-country^title</portal.model.config.name>
                 </configuration>
                 -->
                 <executions>

--- a/samples/DevPortal/shared-pom.xml
+++ b/samples/DevPortal/shared-pom.xml
@@ -35,8 +35,12 @@
                       field represents the machine name of the field within the Developer portal.
 
                       portal.model.config.name can be used to configure the modelName being sent to the SmartDocs API
-                        The caret symbol (^) is used to seperate which fields you want appended to the title from the info object and it will be replaced with _
+                      Without this configuration, the default field used is the title
+                        The caret symbol (^) is used to separate which fields you want extracted from the info object and it will be replaced with _
                         The pipe character is used to traverse into sub-items if necessary
+                      For example, if the OpenAPI document contains { "info": { "title": "Hello World API", "contact": { "x-country": "Canada" } } }
+                      And the config is as below "contact|x-country^title"
+                      The Model Name would be "Canada_Hello-World-API"
                 -->
                 <!--
                 <configuration>

--- a/samples/README.md
+++ b/samples/README.md
@@ -106,7 +106,9 @@ To run jump to samples project `cd /samples/DevPortal` and run
 
 `mvn install -Pdev -Dapigee.smartdocs.config.options=create`
 
-#### Configuring the model name on the Developer Portal
+#### Configuring the model name on the Developer Portal (Optional)
+
+The default model name without this configuration is the title field from the info object.
 
 If you would like to configure the model name of the SmartDoc on the developer portal, you can use additional fields from the OpenAPI specification. The default model name is based on the title.
 
@@ -117,6 +119,8 @@ If you would like to configure the model name of the SmartDoc on the developer p
         <portal.model.config.name>contact|x-country^title</portal.model.config.name>
         ...
     </configuration>
+
+ The caret symbol (^) is used to separate which fields you want extracted from the info object and it will be replaced with underscore (_) in the name
     
 The example config above would generate a model name based on the info object OpenAPI document. For instance, an OpenAPI document containing:
 ```json

--- a/samples/README.md
+++ b/samples/README.md
@@ -106,6 +106,30 @@ To run jump to samples project `cd /samples/DevPortal` and run
 
 `mvn install -Pdev -Dapigee.smartdocs.config.options=create`
 
+#### Configuring the model name on the Developer Portal
+
+If you would like to configure the model name of the SmartDoc on the developer portal, you can use additional fields from the OpenAPI specification. The default model name is based on the title.
+
+ In order to configure it to generate a unique model name, you will need to specify the format in the shared-pom.xml
+ 
+     <configuration>
+        ...
+        <portal.model.config.name>contact|x-country^title</portal.model.config.name>
+        ...
+    </configuration>
+    
+The example config above would generate a model name based on the info object OpenAPI document. For instance, an OpenAPI document containing:
+```json
+{
+  "info": {
+    "title": "Hello World API",
+    "contact": {
+      "x-country": "Canada"
+    }
+  }
+}
+```
+The model name would be `Canada_Hello-World-API`
 
 ### Troubleshooting
 

--- a/src/main/java/com/apigee/smartdocs/config/mavenplugin/APIModelMojo.java
+++ b/src/main/java/com/apigee/smartdocs/config/mavenplugin/APIModelMojo.java
@@ -241,7 +241,7 @@ public class APIModelMojo extends GatewayAbstractMojo {
         for (File file : files) {
           logger.info("FilePath: " + file.getPath());
           PortalRestUtil.SpecObject spec = PortalRestUtil.parseSpec(serverProfile, file);
-          specNames.add(spec.getName());
+          specNames.add(spec.getName(serverProfile.getPortalModelNameConfig()));
         }
       }
 
@@ -271,7 +271,7 @@ public class APIModelMojo extends GatewayAbstractMojo {
         for (File file : files) {
           logger.info("FilePath: " + file.getPath());
           PortalRestUtil.SpecObject spec = PortalRestUtil.parseSpec(serverProfile, file);
-          specNames.add(spec.getName());
+          specNames.add(spec.getName(serverProfile.getPortalModelNameConfig()));
         }
       }
 
@@ -325,7 +325,7 @@ public class APIModelMojo extends GatewayAbstractMojo {
           logger.info("Pushing fields for " + spec.getTitle());
           for (PortalRestUtil.TaxonomyTermObject to: tos) {
             // Match file and taxonomy term.
-            if (to.name.equals(spec.getName())) {
+            if (to.name.equals(spec.getName(serverProfile.getPortalModelNameConfig()))) {
               HashMap hs = new HashMap();
               for (PortalField pf : modelFields.values()) {
                 // Elements can be embedded within the info object, so

--- a/src/main/java/com/apigee/smartdocs/config/mavenplugin/GatewayAbstractMojo.java
+++ b/src/main/java/com/apigee/smartdocs/config/mavenplugin/GatewayAbstractMojo.java
@@ -149,10 +149,17 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
    * @parameter property="portal.cronkey"
    */
   private String portalCronKey;
-  
+
+  /**
+   * Portal Model Name Config
+   *
+   * @parameter alias="portal.model.config.name"
+   */
+  private String portalModelNameConfig;
+
   /**
    * Skip running this plugin. Default is false.
-   *   
+   *
 * @parameter default-value="false"
    */
   private boolean skip = false;
@@ -175,6 +182,7 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
     this.buildProfile.setPortalModelFields(this.portalModelFields);
     this.buildProfile.setPortalModelVocabulary(this.portalModelVocabulary);
     this.buildProfile.setPortalCronKey(this.portalCronKey);
+    this.buildProfile.setPortalModelNameConfig(this.portalModelNameConfig);
 
     return buildProfile;
   }

--- a/src/main/java/com/apigee/smartdocs/config/utils/ServerProfile.java
+++ b/src/main/java/com/apigee/smartdocs/config/utils/ServerProfile.java
@@ -31,6 +31,7 @@ public class ServerProfile {
   private String portalFormat; // OpenAPI spec format
   private String portalModelVocabulary; // Model Vocabulary
   private String portalCronKey; // Dev portal Cron Key
+  private String portalModelNameConfig; // OPTIONAL configuration for Model Name
   private Map<String, PortalField> portalModelFields; // OpenAPI spec format
 
   /**
@@ -130,7 +131,7 @@ public class ServerProfile {
   public String getPortalModelVocabulary() {
     return portalModelVocabulary;
   }
-  
+
   /**
    * @param portalCronKey the portalCronKey to set
    */
@@ -170,4 +171,17 @@ public class ServerProfile {
     this.options = options;
   }
 
+  /**
+   * @return the PortalModelNameConfig
+   */
+  public String getPortalModelNameConfig() {
+    return portalModelNameConfig;
+  }
+
+  /**
+   * @param portalModelNameConfig the portalModelNameConfig to set
+   */
+  public void setPortalModelNameConfig(String portalModelNameConfig) {
+    this.portalModelNameConfig = portalModelNameConfig;
+  }
 }


### PR DESCRIPTION
This change generates a unique model name based on configuration in the pom.xml

If no configuration is provided, it will use the title as the model name, same as previous versions.