### PR TITLE
Remove special characters from customized model name

### DIFF
--- a/src/main/java/com/apigee/smartdocs/config/rest/PortalRestUtil.java
+++ b/src/main/java/com/apigee/smartdocs/config/rest/PortalRestUtil.java
@@ -145,6 +145,13 @@ public class PortalRestUtil {
             returnString += "_";
         }
       }
+      //Clean the return string to only include Alphanumeric characters, underscore and dash
+      returnString = returnString.replaceAll("[^A-Za-z0-9_-]","");
+      //set Max length to be 255
+      if(returnString.length() > 255) {
+        returnString = returnString.substring(0,255);
+      }
+      logger.debug("API Model Name: " + returnString);
       return returnString;
     }
 


### PR DESCRIPTION
Sanitize model name string to only contain alphanumeric characters, underscore and dash

Additionally restrict length to be less than 255 chars