### PR TITLE
Change custom portal model name seperator to dash

### DIFF
--- a/samples/DevPortal/shared-pom.xml
+++ b/samples/DevPortal/shared-pom.xml
@@ -35,12 +35,12 @@
                       field represents the machine name of the field within the Developer portal.
 
                       portal.model.config.name can be used to configure the modelName being sent to the SmartDocs API
-                      Without this configuration, the default field used is the title
-                        The caret symbol (^) is used to separate which fields you want extracted from the info object and it will be replaced with _
+                      Without this configuration, the default field used is the title which has spaces replaced by dashes
+                        The caret symbol (^) is used to separate which fields you want extracted from the info object and it will be replaced with dash (-)
                         The pipe character is used to traverse into sub-items if necessary
                       For example, if the OpenAPI document contains { "info": { "title": "Hello World API", "contact": { "x-country": "Canada" } } }
                       And the config is as below "contact|x-country^title"
-                      The Model Name would be "Canada_Hello-World-API"
+                      The Model Name would be "Canada-Hello-World-API"
                 -->
                 <!--
                 <configuration>

--- a/samples/README.md
+++ b/samples/README.md
@@ -120,7 +120,9 @@ If you would like to configure the model name of the SmartDoc on the developer p
         ...
     </configuration>
 
- The caret symbol (^) is used to separate which fields you want extracted from the info object and it will be replaced with underscore (_) in the name
+ The caret symbol (^) is used to separate which fields you want extracted from the info object and it will be replaced with dash (-) in the name
+
+ Additionally, spaces and periods are converted to dashes
     
 The example config above would generate a model name based on the info object OpenAPI document. For instance, an OpenAPI document containing:
 ```json
@@ -133,7 +135,7 @@ The example config above would generate a model name based on the info object Op
   }
 }
 ```
-The model name would be `Canada_Hello-World-API`
+The model name would be `Canada-Hello-World-API`
 
 ### Troubleshooting
 

--- a/src/main/java/com/apigee/smartdocs/config/rest/PortalRestUtil.java
+++ b/src/main/java/com/apigee/smartdocs/config/rest/PortalRestUtil.java
@@ -140,13 +140,13 @@ public class PortalRestUtil {
       while (it.hasNext()) {
         String namePart = (String) it.next();
         returnString += namePart;
-        //Seperate fields with underscore
+        //Separate fields with dash
         if(it.hasNext()) {
-            returnString += "_";
+            returnString += "-";
         }
       }
-      //Clean the return string to only include Alphanumeric characters, underscore and dash
-      returnString = returnString.replaceAll("[^A-Za-z0-9_-]","");
+      //Clean the return string to only include Alphanumeric characters and the dash character
+      returnString = returnString.replaceAll("[^A-Za-z0-9-]","");
       //set Max length to be 255
       if(returnString.length() > 255) {
         returnString = returnString.substring(0,255);


### PR DESCRIPTION
The URL generated from the model name removed the underscore character and so this change simply changes the separator so that the URL for a specific model is easier to read